### PR TITLE
RDM-1575: Support for OAuth2 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Implementation of a default print service for case data.
 ## Overview
 [Express](http://expressjs.com) application that allows an authorised user to retrieve case data in a printable format.
 
+The output comprises a summary, with some key information such as Case Number and user requesting the printout, followed by a dump of the case details in JSON format.
+
 ## Getting started
 
 ### Prerequisites
@@ -17,7 +19,7 @@ The following environment variables are required:
 |------|---------|-------------|
 | IDAM_BASE_URL | - | Base URL for IdAM's User API service (idam-app). `http://localhost:4501` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_S2S_URL | - | Base URL for IdAM's S2S API service (service-auth-provider). `http://localhost:4502` for the dockerised local instance or tunnelled `dev` instance. |
-| IDAM_SERVICE_KEY | - | Print Service's IdAM S2S micro-service secret key. This must match the IdAM instance it's being run against. |
+| IDAM_PRINT_SERVICE_KEY | - | Print Service's IdAM S2S micro-service secret key. This must match the IdAM instance it's being run against. |
 | CASE_DATA_STORE_URL | - | Base URL for the Case Data Store service. `http://localhost:4452` for the dockerised local instance. |
 
 ### Building
@@ -35,15 +37,22 @@ Start the application by executing the following command:
 npm start
 ```
 
+**Note:** You can also use [yarn](https://yarnpkg.com/lang/en/) in place of npm, in both commands above.
+
 ### Accessing the service
 
-The application is running on HTTPS, port 3100 by default.
+The application uses HTTP, port 3100 by default.
 
 Access to any case data requires an authorised user that is already authenticated via IdAM (and thus, has been granted a Java Web Token (JWT) for the session).
 
-Point your browser at https://localhost:3100/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}?jwt={token}, where:
+Point your browser at http://localhost:3100/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}?jwt={token}, where:
 
 - `{jid}` is the Jurisdiction ID, for example, `PROBATE`
 - `{ctid}` is the Case Type ID, for example, `GrantOfRepresentation`
 - `{cid}` is the Case ID, for example, `1111222233334444`
 - `{token}` is the user's JWT, which is already stored as a browser cookie for an authenticated user
+
+Alternatively, you can mimic the result of the OAuth 2.0 "lite" authentication flow, by omitting the `jwt` query parameter from the URL above, and setting the JWT as a cookie instead:
+
+1. Open your browser's Developer Tools window (typically by pressing F12).
+2. In the console, enter the JavaScript command: `document.cookie="accessToken={token}"` where `{token}` is the user's JWT.

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -7,7 +7,7 @@ security:
 idam:
   base_url: IDAM_BASE_URL
   s2s_url: IDAM_S2S_URL
-  service_key: IDAM_SERVICE_KEY
+  print_service_key: IDAM_PRINT_SERVICE_KEY
   service_name: IDAM_SERVICE_NAME
 case_data_store_url: CASE_DATA_STORE_URL
 case_data_probate_template_url: CASE_DATA_PROBATE_TEMPLATE_URL

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,7 +7,7 @@ security:
 idam:
   base_url: http://localhost:4501
   s2s_url: http://localhost:4502
-  service_key: AAAAAAAAAAAAAAAA
+  print_service_key: AAAAAAAAAAAAAAAA
   service_name: ccd_ps
 case_data_store_url: http://localhost:4452
 case_data_probate_template_url: http://localhost:4104

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^2.2.43",
+    "@types/sinon-chai": "^2.7.29",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "debug": "^3.0.1",

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 import { Logger } from "@hmcts/nodejs-logging";
-import * as fs from "fs";
-import * as https from "https";
-import * as path from "path";
 import { app } from "./app";
 
 const logger = Logger.getLogger("server");
@@ -10,18 +7,6 @@ const logger = Logger.getLogger("server");
 // TODO: set the right port for your application
 const port: number = parseInt(process.env.PORT, 10) || 3100;
 
-if (app.locals.ENV === "dev") {
-  const sslDirectory = path.join(__dirname, "resources", "localhost-ssl");
-  const sslOptions = {
-    cert: fs.readFileSync(path.join(sslDirectory, "localhost.crt")),
-    key: fs.readFileSync(path.join(sslDirectory, "localhost.key")),
-  };
-  const server = https.createServer(sslOptions, app);
-  server.listen(port, () => {
-    logger.info(`Application started: https://localhost:${port}`);
-  });
-} else {
-  app.listen(port, () => {
-    logger.info(`Application started: http://localhost:${port}`);
-  });
-}
+app.listen(port, () => {
+  logger.info(`Application started: http://localhost:${port}`);
+});

--- a/src/main/service/case-service.ts
+++ b/src/main/service/case-service.ts
@@ -1,13 +1,15 @@
 import { get } from "config";
 import { fetch } from "../util/fetch";
+import * as userReqAuth from "../user/user-request-authorizer";
 
 export function getCase(req, jid, ctid, cid) {
   let userId = req.authentication.user.id;
   let url = get("case_data_store_url") + '/caseworkers/' + userId + '/jurisdictions/' + jid + '/case-types/' + ctid +
     '/cases/' + cid;
+  let authorization = req.cookies['jwt'] ? `Bearer ${req.cookies['jwt']}` : req.headers[userReqAuth.AUTHORIZATION];
   return fetch(url, { method: 'GET',
                       headers: {
-                        'Authorization': 'Bearer ' + req.cookies['jwt'],
+                        'Authorization': authorization,
                         'ServiceAuthorization': req.headers.ServiceAuthorization,
                         'Content-Type': 'application/json'
                       }

--- a/src/main/service/case-service.ts
+++ b/src/main/service/case-service.ts
@@ -6,7 +6,7 @@ export function getCase(req, jid, ctid, cid) {
   let userId = req.authentication.user.id;
   let url = get("case_data_store_url") + '/caseworkers/' + userId + '/jurisdictions/' + jid + '/case-types/' + ctid +
     '/cases/' + cid;
-  let authorization = req.cookies['jwt'] ? `Bearer ${req.cookies['jwt']}` : req.headers[userReqAuth.AUTHORIZATION];
+  let authorization = req.cookies['jwt'] ? `Bearer ${req.cookies['jwt']}` : req.get(userReqAuth.AUTHORIZATION);
   return fetch(url, { method: 'GET',
                       headers: {
                         'Authorization': authorization,

--- a/src/main/service/service-token-generator.ts
+++ b/src/main/service/service-token-generator.ts
@@ -6,7 +6,7 @@ import { fetch } from "../util/fetch";
 
 const idamS2SUrl = get("idam.s2s_url");
 const serviceName = get("idam.service_name");
-const secret = get("idam.service_key");
+const secret = get("idam.print_service_key");
 
 // TODO Caching should be handled by a singleton service
 const cache = {};

--- a/src/main/user/user-request-authorizer.ts
+++ b/src/main/user/user-request-authorizer.ts
@@ -17,7 +17,7 @@ export const ERROR_UNAUTHORISED_USER_ID = {
 };
 
 export const COOKIE_ACCESS_TOKEN = 'accessToken';
-export const AUTHORIZATION = 'authorization';
+export const AUTHORIZATION = 'Authorization';
 
 export const authorise = (request) => {
   let user;

--- a/src/main/user/user-request-authorizer.ts
+++ b/src/main/user/user-request-authorizer.ts
@@ -17,7 +17,7 @@ export const ERROR_UNAUTHORISED_USER_ID = {
 };
 
 export const COOKIE_ACCESS_TOKEN = 'accessToken';
-export const AUTHORIZATION = 'Authorization';
+export const AUTHORIZATION = 'authorization';
 
 export const authorise = (request) => {
   let user;

--- a/src/main/user/user-resolver.ts
+++ b/src/main/user/user-resolver.ts
@@ -1,7 +1,7 @@
 import { get } from "config";
 import { fetch } from "../util/fetch";
 
-export const resolveUser = (jwt) => {
+export const getTokenDetails = (jwt) => {
   let bearerJwt = jwt.startsWith("Bearer ") ? jwt : "Bearer " + jwt;
 
   return fetch(`${get('idam.base_url')}/details`, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,17 @@
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
 
+"@types/sinon-chai@^2.7.29":
+  version "2.7.29"
+  resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-2.7.29.tgz#4db01497e2dd1908b2bd30d1782f456353f5f723"
+  dependencies:
+    "@types/chai" "*"
+    "@types/sinon" "*"
+
+"@types/sinon@*":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-4.3.0.tgz#7f53915994a00ccea24f4e0c24709822ed11a3b1"
+
 a-sync-waterfall@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz#38e8319d79379e24628845b53b96722b29e0e47c"
@@ -3408,6 +3419,10 @@ moment@^2.19.3:
   version "2.19.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.4.tgz#17e5e2c6ead8819c8ecfad83a0acccb312e94682"
 
+moment@^2.9.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
+
 moo-server@*, moo-server@1.3.x:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/moo-server/-/moo-server-1.3.0.tgz#5dc79569565a10d6efed5439491e69d2392e58f1"
@@ -3713,6 +3728,10 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+numeral@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
+
 nunjucks-async-loader@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/nunjucks-async-loader/-/nunjucks-async-loader-1.1.4.tgz#bc460f4e790bb39d8dac9c07528da16ed83f707c"
@@ -3720,6 +3739,18 @@ nunjucks-async-loader@^1.1.1:
     chokidar "^1.4.3"
     co "^4.6.0"
     es6-promisify "^4.0.0"
+
+nunjucks-date-filter@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/nunjucks-date-filter/-/nunjucks-date-filter-0.1.1.tgz#a936d44d2cc9898d95c6ab7b2aba7084fa60aba6"
+  dependencies:
+    moment "^2.9.0"
+
+nunjucks-numeral-filter@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/nunjucks-numeral-filter/-/nunjucks-numeral-filter-0.0.2.tgz#6ef52fa6870bca7bdb83d210056c81d20628a346"
+  dependencies:
+    numeral "^2.0.4"
 
 nunjucks@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Amended authentication to allow obtaining JWT from the `accessToken` cookie, when present in the request, and to set this in the `Authorization` header for outgoing requests.