### PR TITLE
Update main.tf

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,9 +49,6 @@ module "ccd-case-print-service" {
     IDAM_AUTHENTICATION_WEB_URL = "${var.authentication_web_url}"
     IDAM_S2S_AUTH = "${var.s2s_url}"
 
-    IDAM_OAUTH2_TOKEN_ENDPOINT = "${var.idam_api_url}/oauth2/token"
-    IDAM_OAUTH2_CLIENT_ID = "ccd_gateway"
-
     IDAM_BASE_URL = "${var.idam_api_url}"
     IDAM_S2S_URL = "${var.s2s_url}"
     IDAM_SERVICE_NAME = "${var.idam_service_name}"


### PR DESCRIPTION
Remove redundant OAuth2 application variables.

### JIRA link ###
None.

### Change description ###
Removed `IDAM_OAUTH2_TOKEN_ENDPOINT` and `IDAM_OAUTH2_CLIENT_ID`, since Case Print Service application does not perform OAuth2 authentication.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
