### PR TITLE
CCD-36 Add validation for luhn to services

### DIFF
--- a/aat/src/resources/features/F-023/F-023.feature
+++ b/aat/src/resources/features/F-023/F-023.feature
@@ -53,14 +53,26 @@ Scenario: Must return a negative response on callback failure
       And the response has all the details as expected.
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-# RDM-7436 / AC-4
-@S-004
+@S-004.1
 Scenario: Must return a negative response on malformed Case ID
 
     Given a user with [an active profile in CCD - who wants to see the content of a case as a printable document],
 
      When a request is prepared with appropriate values,
-      And the request [contains a malformed case ID],
+      And the request [contains a malformed Case Reference with arbitrary chars],
+      And it is submitted to call the [Get Case as Printable Document] operation of [CCD Case Print Service API],
+
+     Then a negative response is received,
+      And the response has all the details as expected.
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+@S-004.2
+Scenario: Must return a negative response for a non-luhn numeric Case Reference
+
+    Given a user with [an active profile in CCD - who wants to see the content of a case as a printable document],
+
+     When a request is prepared with appropriate values,
+      And the request [contains a non-luhn numeric Case Reference],
       And it is submitted to call the [Get Case as Printable Document] operation of [CCD Case Print Service API],
 
      Then a negative response is received,

--- a/aat/src/resources/features/F-023/S-004.1.td.json
+++ b/aat/src/resources/features/F-023/S-004.1.td.json
@@ -1,11 +1,11 @@
 {
-	"_guid_": "S-004",
+	"_guid_": "S-004.1",
 	"_extends_": "F-023_Test_Data_Base",
 	"title": "Must return a negative response on malformed Case ID",
 
 	"specs": [
 		"an active profile in CCD - who wants to see the content of a case as a printable document",
-		"contains a malformed case ID"
+		"contains a malformed Case Reference with arbitrary chars"
 	],
 
 	"request": {
@@ -14,15 +14,17 @@
 		}
 	},
 
+
 	"expectedResponse": {
 		"_extends_": "Common_400_Response",
 		"body": {
-			"status": "[[ANY_NULLABLE]]",
-			"error": "[[ANY_NULLABLE]]",
+			"code" : "INVALID_CASE_ID",
+			"message" : "Case ID must be a valid luhn number",
+			"status" : 400,
+			"error": "Bad Request",
 			"timestamp": "[[ANY_NULLABLE]]",
-			"path":"[[ANY_NULLABLE]]",
-			"size" : 0,
-			"timeout" : 0
+			"path":"[[ANY_NULLABLE]]"
 		}
 	}
+
 }

--- a/aat/src/resources/features/F-023/S-004.2.td.json
+++ b/aat/src/resources/features/F-023/S-004.2.td.json
@@ -1,0 +1,16 @@
+{
+	"_guid_": "S-004.2",
+	"_extends_": "S-004.1",
+
+	"title": "Must return a negative response for a non-luhn numeric Case Reference",
+
+	"specs": [
+		"contains a non-luhn numeric Case Reference"
+	],
+
+	"request": {
+		"pathVariables": {
+			"cid": "111111111111"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "helmet": "^3.8.1",
     "jquery": "^3.5.1",
     "jwt-decode": "^2.2.0",
+    "luhn": "^2.4.1",
     "mime": "^1.4.0",
     "node-fetch": "^2.6.1",
     "node-sass": "^4.12.0",
@@ -134,7 +135,8 @@
     "merge": "^2.1.1",
     "glob-parent": "~5.1.2",
     "trim-newlines": "^3.0.1",
-    "normalize-url": "^4.5.1"
+    "normalize-url": "^4.5.1",
+    "@snyk/cli-interface": "2.9.0"
   },
   "snyk": true,
   "nyc": {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -86,5 +86,10 @@ app.use((err, req, res, next) => {
   res.locals.error = env === "development" ? err : {};
 
   res.status(err.status || 500);
-  res.render("error");
+
+  if (err.code === "INVALID_CASE_ID") {
+    res.send(err);
+  } else {
+    res.render("error");
+  }
 });

--- a/src/main/service/case-service.ts
+++ b/src/main/service/case-service.ts
@@ -1,8 +1,10 @@
 import { get } from "config";
 import { fetch } from "../util/fetch";
 import * as userReqAuth from "../user/user-request-authorizer";
+import * as validate from "../util/validate";
 
 export function getCase(req, jid, ctid, cid) {
+  validate.isLuhn(cid);
   const userId = req.authentication.user.uid;
   const url = get("case_data_store_url") + "/caseworkers/" + userId + "/jurisdictions/" + jid + "/case-types/" + ctid +
     "/cases/" + cid;

--- a/src/main/service/probate-man-service.ts
+++ b/src/main/service/probate-man-service.ts
@@ -1,17 +1,20 @@
 import { get } from "config";
 import { fetch } from "../util/fetch";
 import * as userReqAuth from "../user/user-request-authorizer";
+import * as validate from "../util/validate";
 
 export function getProbateManLegacyCase(req, probateManType, id) {
   const url = get("case_data_probate_template_url") + "/probateManTypes/" + probateManType + "/cases/" + id;
   const authorization = req.get(userReqAuth.AUTHORIZATION);
+  validate.isLuhn(id);
+
   return fetch(url, {
-                      headers: {
-                        "Authorization": authorization,
-                        "Content-Type": "application/json",
-                        "ServiceAuthorization": req.headers.ServiceAuthorization,
-                      },
-                      method: "GET",
-                    })
-    .then((res) => res.json());
+    headers: {
+      "Authorization": authorization,
+      "Content-Type": "application/json",
+      "ServiceAuthorization": req.headers.ServiceAuthorization,
+    },
+    method: "GET",
+  })
+  .then((res) => res.json());
 }

--- a/src/main/util/validate.ts
+++ b/src/main/util/validate.ts
@@ -1,0 +1,14 @@
+const luhn = require("luhn");
+
+export function isLuhn(id) {
+  if (!luhn.validate(id)) {
+    throw ERROR_INVALID_CASE_ID;
+  }
+}
+
+export const ERROR_INVALID_CASE_ID = {
+  code: "INVALID_CASE_ID",
+  error: "Bad Request",
+  message: "Case ID must be a valid luhn number",
+  status: 400,
+};

--- a/src/test/service/case-service.spec.ts
+++ b/src/test/service/case-service.spec.ts
@@ -1,0 +1,85 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as proxyquire from "proxyquire";
+import * as sinon from "sinon";
+
+describe("case service", () => {
+
+  let getCase;
+  const serviceAuthorization = "Bearer dghdheh48";
+  const req = {
+    authentication: {
+        user: {
+            uid : "1234",
+        },
+    },
+    cookies: {
+      jwt: "hfsjkfdhsk",
+    },
+    get: sinon.stub(),
+    headers: {
+      ServiceAuthorization : serviceAuthorization,
+    },
+  };
+
+  const expectedErrorStatus = 400;
+  const expectedError = "Bad Request";
+  const expectedErrorMessage = "Case ID must be a valid luhn number";
+
+  beforeEach(() => {
+    const config = {
+      get: sinon.stub(),
+    };
+    config.get.withArgs("case_data_store_url").returns("http://localhost:4104");
+    getCase = proxyquire("../../main/service/case-service", {
+      config,
+    }).getCase;
+  });
+
+  describe("getCase()", () => {
+    it("should return a case", async () => {
+
+      const jid = "jurisdiction";
+      const ctid = "caseTemplateId";
+      const cid = "79927398713";
+      const expectedResult = 79927398713;
+      req.get.withArgs("Authorization").returns(serviceAuthorization);
+
+      nock("http://localhost:4104")
+        .get("/caseworkers/1234/jurisdictions/" + jid + "/case-types/" + ctid +
+        "/cases/" + cid)
+        .reply(200, expectedResult);
+      const result = await getCase(req, jid, ctid, cid);
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it("should return an error when not a luhn", async () => {
+
+        const jid = "jurisdiction";
+        const ctid = "caseTemplateId";
+        const cid = "1";
+        try {
+            await getCase(req, jid, ctid, cid);
+        } catch (error) {
+            expect(error.status).to.deep.equal(expectedErrorStatus);
+            expect(error.error).to.deep.equal(expectedError);
+            expect(error.message).to.deep.equal(expectedErrorMessage);
+        }
+    });
+
+    it("should return an error when not a NaN", async () => {
+
+        const jid = "jurisdiction";
+        const ctid = "caseTemplateId";
+        const cid = "1A";
+        try {
+            await getCase(req, jid, ctid, cid);
+        } catch (error) {
+            expect(error.status).to.deep.equal(expectedErrorStatus);
+            expect(error.error).to.deep.equal(expectedError);
+            expect(error.message).to.deep.equal(expectedErrorMessage);
+        }
+    });
+  });
+
+});

--- a/src/test/service/probate-man-service.spec.ts
+++ b/src/test/service/probate-man-service.spec.ts
@@ -6,6 +6,8 @@ import * as sinon from "sinon";
 describe("probate man service", () => {
 
   let getProbateManLegacyCase;
+  const authorization = "Bearer dghdheh47";
+  const serviceAuthorization = "Bearer dghdheh48";
 
   beforeEach(() => {
     const config = {
@@ -19,8 +21,6 @@ describe("probate man service", () => {
 
   describe("getProbateManLegacyCase()", () => {
     it("should return probate man legacy case", async () => {
-      const authorization = "Bearer dghdheh47";
-      const serviceAuthorization = "Bearer dghdheh48";
       const req = {
         get: sinon.stub(),
         headers: {
@@ -28,12 +28,71 @@ describe("probate man service", () => {
         },
       };
       req.get.withArgs("Authorization").returns(authorization);
-      const expectedResult = {id: 1};
+      const expectedResult = {id: 79927398713};
       nock("http://localhost:4104")
-        .get("/probateManTypes/CAVEAT/cases/1")
+        .get("/probateManTypes/CAVEAT/cases/79927398713")
         .reply(200, expectedResult);
 
-      const result = await getProbateManLegacyCase(req, "CAVEAT", 1);
+      const result = await getProbateManLegacyCase(req, "CAVEAT", 79927398713);
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it ("should return an error when NaN", async () => {
+      const req = {
+        get: sinon.stub(),
+        headers: {
+          ServiceAuthorization : serviceAuthorization,
+        },
+      };
+      req.get.withArgs("Authorization").returns(authorization);
+      const expectedStatus = 400;
+      const expectedError = "Bad Request";
+      const expectedMessage = "Case ID must be a valid luhn number";
+
+      try {
+        await getProbateManLegacyCase(req, "CAVEAT", "A1");
+      } catch (error) {
+        expect(error.status).to.deep.equal(expectedStatus);
+        expect(error.error).to.deep.equal(expectedError);
+        expect(error.message).to.deep.equal(expectedMessage);
+      }
+    });
+
+    it ("should return an error when not a luhn", async () => {
+      const req = {
+        get: sinon.stub(),
+        headers: {
+          ServiceAuthorization : serviceAuthorization,
+        },
+      };
+      req.get.withArgs("Authorization").returns(authorization);
+      const expectedStatus = 400;
+      const expectedError = "Bad Request";
+      const expectedMessage = "Case ID must be a valid luhn number";
+
+      try {
+        await getProbateManLegacyCase(req, "CAVEAT", 1);
+      } catch (error) {
+        expect(error.status).to.deep.equal(expectedStatus);
+        expect(error.error).to.deep.equal(expectedError);
+        expect(error.message).to.deep.equal(expectedMessage);
+      }
+    });
+
+    it("should return probate man legacy case when using vaild luhn string", async () => {
+      const req = {
+        get: sinon.stub(),
+        headers: {
+          ServiceAuthorization : serviceAuthorization,
+        },
+      };
+      req.get.withArgs("Authorization").returns(authorization);
+      const expectedResult = {id: 79927398713};
+      nock("http://localhost:4104")
+        .get("/probateManTypes/CAVEAT/cases/79927398713")
+        .reply(200, expectedResult);
+
+      const result = await getProbateManLegacyCase(req, "CAVEAT", "79927398713");
       expect(result).to.deep.equal(expectedResult);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6298,6 +6298,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luhn@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/luhn/-/luhn-2.4.1.tgz#9cf501c5d0e9f7ee79504338ae71c9bcc67c304a"
+  integrity sha512-p1eEWSb2RJAfv+BzrPEUqbUXV1H3ylHEAOk9yDM1L12ojD6OQQGrE29DqKLa0XYluJTIwXIOFmyzVOme3QSyww==
+
 macos-release@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.0.tgz#837b39fc01785c3584f103c5599e0f0c8068b49e"


### PR DESCRIPTION
### JIRA link ###
[CCD-36](https://tools.hmcts.net/jira/browse/CCD-36)


### Change description ###
Updated probate-man-service to validate ID ensuring invalid LUHN returns a bad request response


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
