### PR TITLE
CCD-1945, CCD-1946 & CCD-1947

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "trim-newlines": "^3.0.1",
     "normalize-url": "^4.5.1",
     "@snyk/cli-interface": "2.9.0",
-    "tar": "^6.1.1",
+    "tar": "^6.1.9",
     "jszip": "^3.7.0",
     "path-parse": "^1.0.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7497,7 +7497,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@1.0.7, path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -9682,10 +9682,10 @@ tar-stream@^2.1.0, tar-stream@^2.1.2:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^2.0.0, tar@^6.1.1:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@^2.0.0, tar@^6.1.9:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
### [CCD-1945](https://tools.hmcts.net/jira/browse/CCD-1945) ###
### [CCD-1946](https://tools.hmcts.net/jira/browse/CCD-1946) ###
### [CCD-1947](https://tools.hmcts.net/jira/browse/CCD-1947) ###


### Change description ###
Bumped transient dependency tar to v6.1.9 to resolve the following CVE's:
[CVE-2021-37701](https://nvd.nist.gov/vuln/detail/CVE-2021-37701)
[CVE-2021-37712](https://nvd.nist.gov/vuln/detail/CVE-2021-37712)
[CVE-2021-37713](https://nvd.nist.gov/vuln/detail/CVE-2021-37713)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
