### PR TITLE
CCD-2312: Temporarily disable Fortify Scan in nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -14,10 +14,11 @@ def component = "case-print-service"
 withNightlyPipeline(type, product, component) {
     enableSlackNotifications('#ccd-nightly-builds')
 
-    enableFortifyScan()
-    after('fortify-scan') {
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
-    }
+    // Temporarily disable fortify scan stage until fortify access re-enabled
+    //enableFortifyScan()
+    //after('fortify-scan') {
+    //  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
+    //}
 
     afterCheckout {
         sh "yarn cache clean"


### PR DESCRIPTION
### JIRA link ###
CCD-2312 (https://tools.hmcts.net/jira/browse/CCD-2312)


### Change description ###
Temporarily disable the Fortify Scan stage in the nightly build until Fortify access is re-enabled.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
