### PR TITLE
CME-559 Replaced JitPack with Azure DevOps Artifacts

### DIFF
--- a/aat/build.gradle
+++ b/aat/build.gradle
@@ -14,14 +14,15 @@ repositories {
   mavenLocal()
   mavenCentral()
   maven {
-    url 'https://jitpack.io'
+    name = "AzureArtifacts"
+    url = uri("https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1")
   }
 }
 
 dependencies {
   testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.24.2'
   testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '9.2.0'
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.5'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9'
 }
 
 sourceSets {


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/CME-559

### Change description ###

Replaced JitPack with Azure DevOps Artifacts and upgraded Fortify client version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
