### PR TITLE
adding check for dev to include unsafe-eval and unsafe-inline due to …

### DIFF
--- a/src/main/modules/helmet/index.ts
+++ b/src/main/modules/helmet/index.ts
@@ -31,19 +31,32 @@ export class Helmet {
   }
 
   private setContentSecurityPolicy(app) {
-    app.use(helmet.contentSecurityPolicy(
-      {
-        directives: {
-          connectSrc: [self],
-          defaultSrc: ["'none'"],
-          fontSrc: [self, "data:"],
-          imgSrc: [self, googleAnalyticsDomain, hmctsPiwikDomain],
-          objectSrc: [self],
-          scriptSrc: [self, googleAnalyticsDomain, hmctsPiwikDomain],
-          styleSrc: [self],
+    private setContentSecurityPolicy(app) {
+      const scriptSources = [self, googleAnalyticsDomain, hmctsPiwikDomain];
+
+      // Adding 'unsafe-eval' weakens  CSP protection.
+      // The conditional approach ensures it's only allowed in development
+      // where debugging tools might need it, while maintaining security in production.
+      // Add unsafe-eval only in development
+      if (app.locals.developmentMode) {
+        scriptSources.push("'unsafe-eval'");
+        scriptSources.push("'unsafe-inline'");
+      }
+
+      app.use(helmet.contentSecurityPolicy(
+        {
+          directives: {
+            connectSrc: [self],
+            defaultSrc: ["'none'"],
+            fontSrc: [self, "data:"],
+            imgSrc: scriptSources,
+            objectSrc: [self],
+            scriptSrc: scriptSources,
+            styleSrc: [self],
+          },
         },
-      },
-    ));
+      ));
+    }
   }
 
   private setReferrerPolicy(app, policy) {


### PR DESCRIPTION
…ERROR: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' *.google-analytics.com hmctspiwik.useconnect.co.uk

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] the `keep-helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
