### PR TITLE
Enable CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -5,7 +5,7 @@ properties(
          pipelineTriggers([[$class: 'GitHubPushTrigger']])]
 )
 
-@Library("Infrastructure")
+@Library("Infrastructure@cve-dashboard")
 
 def product = "ccd"
 def component = "case-print-service"
@@ -100,6 +100,7 @@ withPipeline("nodejs", product, component) {
 
     enableAksStagingDeployment()
     disableLegacyDeployment()
+    enableCveDashboardIngestion()
     enableHighLevelDataSetup()
 
     afterAlways('checkout') {


### PR DESCRIPTION
## Summary
- use the CVE Dashboard branch of the shared Jenkins Infrastructure library
- enable CVE Dashboard ingestion using the default production branch behaviour

## Context
This follows the test wiring from hmcts/ccd-admin-web#883, but uses the production enableCveDashboardIngestion() call without explicit branch overrides.

## Testing
- Not run; Jenkins pipeline configuration change only