### PR TITLE
Re-onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -5,7 +5,7 @@ properties(
          pipelineTriggers([[$class: 'GitHubPushTrigger']])]
 )
 
-@Library("Infrastructure@2.4.9")
+@Library("Infrastructure@cve-dashboard")
 
 def product = "ccd"
 def component = "case-print-service"
@@ -100,7 +100,7 @@ withPipeline("nodejs", product, component) {
 
     enableAksStagingDeployment()
     disableLegacyDeployment()
-    //enableCveDashboardIngestion()
+    enableCveDashboardIngestion()
     enableHighLevelDataSetup()
 
     afterAlways('checkout') {


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- re-enable CVE dashboard ingestion

## Testing
- Jenkinsfile-only configuration change